### PR TITLE
ナビゲーションバー周りの設定

### DIFF
--- a/MolkkyScoreBoard/MolkkyScoreBoard/UI/Common/DestinationHolderView.swift
+++ b/MolkkyScoreBoard/MolkkyScoreBoard/UI/Common/DestinationHolderView.swift
@@ -50,7 +50,6 @@ struct DestinationHolderView<Content:View>: View {
             .navigationBarTitleDisplayMode(.inline)
         }
         .environmentObject(router)
-//        .accentColor(Color.white)
     }
 }
 

--- a/MolkkyScoreBoard/MolkkyScoreBoard/UI/Common/DestinationHolderView.swift
+++ b/MolkkyScoreBoard/MolkkyScoreBoard/UI/Common/DestinationHolderView.swift
@@ -50,6 +50,7 @@ struct DestinationHolderView<Content:View>: View {
             .navigationBarTitleDisplayMode(.inline)
         }
         .environmentObject(router)
+//        .accentColor(Color.white)
     }
 }
 

--- a/MolkkyScoreBoard/MolkkyScoreBoard/UI/Common/NavigationViewAppearance.swift
+++ b/MolkkyScoreBoard/MolkkyScoreBoard/UI/Common/NavigationViewAppearance.swift
@@ -12,11 +12,19 @@ final class NavigationViewAppearance {
 
     /// Appearanceの設定
     static func configure() {
+        // バーの設定
         let appearance = UINavigationBarAppearance()
+        let image = UIImage(systemName: "chevron.backward")?.withTintColor(.white, renderingMode: .alwaysOriginal)
         appearance.configureWithOpaqueBackground()
+        appearance.setBackIndicatorImage(image, transitionMaskImage: image)
         appearance.backgroundColor = UIColor.systemGreen
         appearance.titleTextAttributes = [.foregroundColor: UIColor.white,
                                           .font : UIFont.boldSystemFont(ofSize: 20)]
+
+        // ボタンの設定
+        let backItemAppearance = UIBarButtonItemAppearance()
+        backItemAppearance.normal.titleTextAttributes = [.foregroundColor : UIColor.white]
+        appearance.backButtonAppearance = backItemAppearance
 
         UINavigationBar.appearance().standardAppearance = appearance
         UINavigationBar.appearance().scrollEdgeAppearance = appearance

--- a/MolkkyScoreBoard/MolkkyScoreBoard/UI/MolkkyPlay/Views/MolkkyPlayView.swift
+++ b/MolkkyScoreBoard/MolkkyScoreBoard/UI/MolkkyPlay/Views/MolkkyPlayView.swift
@@ -39,6 +39,7 @@ struct MolkkyPlayView: View {
                 TeamScoresView(viewStore: viewStore)
             }
         }
+        .navigationBarBackButtonHidden(true)
     }
 }
 

--- a/MolkkyScoreBoard/MolkkyScoreBoard/UI/Result/Views/ResultView.swift
+++ b/MolkkyScoreBoard/MolkkyScoreBoard/UI/Result/Views/ResultView.swift
@@ -25,6 +25,7 @@ struct ResultView: View {
                     .padding()
             }
         }
+        .navigationBarBackButtonHidden(true)
     }
 }
 


### PR DESCRIPTION
# What changed?✨
- ナビゲーションバーの戻るボタンを白くした
- プレイ画面・結果画面の戻るボタンを削除して戻れなくした

# Impact range🔍
下記のナビゲーションバー
- チーム作成画面
- プレイ順決定画面
- プレイ画面
- 結果画面

# Issues🎫
#13

# Reference📜
- https://developer.apple.com/forums/thread/709517
- https://qiita.com/oYuu/items/d3011e98fa5b809de9f2
- https://qiita.com/GleamingCake/items/1e3aad99b84e16dbf128
