### PR TITLE
1チームの時はプレイ順をスキップする

### DIFF
--- a/MolkkyScoreBoard/MolkkyScoreBoard/Model/TeamScore.swift
+++ b/MolkkyScoreBoard/MolkkyScoreBoard/Model/TeamScore.swift
@@ -15,4 +15,27 @@ struct TeamScore: Identifiable, Hashable, Equatable {
     let setNo: Int
     /// 得点
     var score: Int
+
+    /// Initialize
+    /// - Parameters:
+    ///   - setNo: 何セット目か
+    ///   - score: 得点
+    init(setNo: Int, score: Int) {
+        self.setNo = setNo
+        self.score = score
+    }
+
+    /// Initialize
+    /// - Parameter teams: チーム情報
+    init(from teams: [Team]) {
+        if
+            let team = teams.first,
+            let setNo = team.score.last?.setNo {
+            self.setNo = setNo + 1
+        } else {
+            self.setNo = 1
+        }
+
+        self.score = .zero
+    }
 }

--- a/MolkkyScoreBoard/MolkkyScoreBoard/UI/Common/DestinationHolderView.swift
+++ b/MolkkyScoreBoard/MolkkyScoreBoard/UI/Common/DestinationHolderView.swift
@@ -12,17 +12,14 @@ import ComposableArchitecture
 struct DestinationHolderView<Content:View>: View {
 
     /// Router
-    @ObservedObject private var router: PageRouter
+    @ObservedObject private var router = PageRouter.shared
 
     /// 子ビュー
     private let content: Content
 
     /// Initialize
-    /// - Parameters:
-    ///   - router: PageRouter
-    ///   - content: Content(ViewBuilder)
-    init(router: PageRouter, @ViewBuilder content: () -> Content) {
-        self.router = router
+    /// - Parameter content: Content(ViewBuilder)
+    init(@ViewBuilder content: () -> Content) {
         self.content = content()
     }
 

--- a/MolkkyScoreBoard/MolkkyScoreBoard/UI/Home/HomeTabView.swift
+++ b/MolkkyScoreBoard/MolkkyScoreBoard/UI/Home/HomeTabView.swift
@@ -20,9 +20,6 @@ struct HomeTabView: View {
     /// 選択中のタブ
     @State private var selectedTab: TabType = .play
 
-    /// Router
-    @StateObject private var router = PageRouter.shared
-
     /// Initialize
     init() {
         NavigationViewAppearance.configure()
@@ -30,7 +27,7 @@ struct HomeTabView: View {
     }
 
     var body: some View {
-        DestinationHolderView(router: router) {
+        DestinationHolderView() {
             TabView(selection: $selectedTab) {
                 StartMenuView()
                     .tabItem {

--- a/MolkkyScoreBoard/MolkkyScoreBoard/UI/Result/ResultFeature.swift
+++ b/MolkkyScoreBoard/MolkkyScoreBoard/UI/Result/ResultFeature.swift
@@ -40,7 +40,7 @@ struct ResultFeature: ReducerProtocol {
             sortByPlayingOrder(from: &state)
 
             for index in 0..<state.teams.count {
-                let newScore = newScore(from: state.teams)
+                let newScore = TeamScore(from: state.teams)
                 state.teams[index].score.append(newScore)
             }
 
@@ -69,18 +69,5 @@ private extension ResultFeature {
     func sortByPlayingOrder(from state: inout State) {
         let sortedTeams = state.teams.sorted(by: { $0.order < $1.order })
         state.teams = sortedTeams
-    }
-
-    /// 新たなTeamScoreを取得する
-    /// - Parameter teams: 全チーム情報
-    /// - Returns: TeamScore
-    func newScore(from teams: [Team]) -> TeamScore {
-        if
-            let team = teams.first,
-            let setNo = team.score.last?.setNo {
-            return TeamScore(setNo: setNo + 1, score: .zero)
-        } else {
-            return TeamScore(setNo: 1, score: .zero)
-        }
     }
 }

--- a/MolkkyScoreBoard/MolkkyScoreBoard/UI/Result/ResultFeature.swift
+++ b/MolkkyScoreBoard/MolkkyScoreBoard/UI/Result/ResultFeature.swift
@@ -38,7 +38,14 @@ struct ResultFeature: ReducerProtocol {
         case .didTapNextMatchButton:
             resetIsDisqualified(from: &state)
             sortByPlayingOrder(from: &state)
-            PageRouter.shared.path.append(.teamOrderEdit(teams: state.teams))
+
+            for index in 0..<state.teams.count {
+                let newScore = newScore(from: state.teams)
+                state.teams[index].score.append(newScore)
+            }
+
+            let path: DestinationType = state.teams.count == 1 ? .play(teams: state.teams) : .teamOrderEdit(teams: state.teams)
+            PageRouter.shared.path.append(path)
             return .none
         }
     }
@@ -62,5 +69,18 @@ private extension ResultFeature {
     func sortByPlayingOrder(from state: inout State) {
         let sortedTeams = state.teams.sorted(by: { $0.order < $1.order })
         state.teams = sortedTeams
+    }
+
+    /// 新たなTeamScoreを取得する
+    /// - Parameter teams: 全チーム情報
+    /// - Returns: TeamScore
+    func newScore(from teams: [Team]) -> TeamScore {
+        if
+            let team = teams.first,
+            let setNo = team.score.last?.setNo {
+            return TeamScore(setNo: setNo + 1, score: .zero)
+        } else {
+            return TeamScore(setNo: 1, score: .zero)
+        }
     }
 }

--- a/MolkkyScoreBoard/MolkkyScoreBoard/UI/TeamMake/TeamsMakeFeature.swift
+++ b/MolkkyScoreBoard/MolkkyScoreBoard/UI/TeamMake/TeamsMakeFeature.swift
@@ -77,7 +77,13 @@ struct TeamsMakeFeature: ReducerProtocol {
             return .none
 
         case .didTapDecisionButton:
-            PageRouter.shared.path.append(.teamOrderEdit(teams: state.teams))
+            for index in 0..<state.teams.count {
+                let newScore = newScore(from: state.teams)
+                state.teams[index].score.append(newScore)
+            }
+
+            let path: DestinationType = state.teams.count == 1 ? .play(teams: state.teams) : .teamOrderEdit(teams: state.teams)
+            PageRouter.shared.path.append(path)
             return .none
         }
     }
@@ -126,5 +132,18 @@ private extension TeamsMakeFeature {
         state.invalidIndex.removeAll(where: {
             ($0.team == teamIndex) && ($0.member == memberIndex)
         })
+    }
+
+    /// 新たなTeamScoreを取得する
+    /// - Parameter teams: 全チーム情報
+    /// - Returns: TeamScore
+    func newScore(from teams: [Team]) -> TeamScore {
+        if
+            let team = teams.first,
+            let setNo = team.score.last?.setNo {
+            return TeamScore(setNo: setNo + 1, score: .zero)
+        } else {
+            return TeamScore(setNo: 1, score: .zero)
+        }
     }
 }

--- a/MolkkyScoreBoard/MolkkyScoreBoard/UI/TeamMake/TeamsMakeFeature.swift
+++ b/MolkkyScoreBoard/MolkkyScoreBoard/UI/TeamMake/TeamsMakeFeature.swift
@@ -78,7 +78,7 @@ struct TeamsMakeFeature: ReducerProtocol {
 
         case .didTapDecisionButton:
             for index in 0..<state.teams.count {
-                let newScore = newScore(from: state.teams)
+                let newScore = TeamScore(from: state.teams)
                 state.teams[index].score.append(newScore)
             }
 
@@ -89,7 +89,7 @@ struct TeamsMakeFeature: ReducerProtocol {
     }
 }
 
-// Private Methods
+// MARK: Private Methods
 private extension TeamsMakeFeature {
     /// バリデーションを実施する
     /// - Parameters:
@@ -132,18 +132,5 @@ private extension TeamsMakeFeature {
         state.invalidIndex.removeAll(where: {
             ($0.team == teamIndex) && ($0.member == memberIndex)
         })
-    }
-
-    /// 新たなTeamScoreを取得する
-    /// - Parameter teams: 全チーム情報
-    /// - Returns: TeamScore
-    func newScore(from teams: [Team]) -> TeamScore {
-        if
-            let team = teams.first,
-            let setNo = team.score.last?.setNo {
-            return TeamScore(setNo: setNo + 1, score: .zero)
-        } else {
-            return TeamScore(setNo: 1, score: .zero)
-        }
     }
 }

--- a/MolkkyScoreBoard/MolkkyScoreBoard/UI/TeamsOrderEdit/TeamsOrderEditFeature.swift
+++ b/MolkkyScoreBoard/MolkkyScoreBoard/UI/TeamsOrderEdit/TeamsOrderEditFeature.swift
@@ -37,21 +37,6 @@ struct TeamsOrderEditFeature: ReducerProtocol {
             return .none
 
         case .didTapDecideButton:
-            let newScore: TeamScore
-            if
-                let team = state.teams.first,
-                let setNo = team.score.last?.setNo {
-                newScore = TeamScore(setNo: setNo + 1, score: .zero)
-            } else {
-                newScore = TeamScore(setNo: 1, score: .zero)
-            }
-
-            let teamCount = state.teams.count
-
-            for index in 0..<teamCount {
-                state.teams[index].score.append(newScore)
-            }
-
             PageRouter.shared.path.append(.play(teams: state.teams))
             return .none
         }

--- a/MolkkyScoreBoard/MolkkyScoreBoard/UI/TeamsOrderEdit/Views/TeamsOrderEditView.swift
+++ b/MolkkyScoreBoard/MolkkyScoreBoard/UI/TeamsOrderEdit/Views/TeamsOrderEditView.swift
@@ -55,18 +55,6 @@ struct TeamsOrderEditView: View {
     }
 }
 
-// MARK: Private Methods
-private extension TeamsOrderEditView {
-    /// Storeを取得
-    /// - Parameter teams: チーム情報
-    /// - Returns: StoreOf<MolkkyPlayFeature>
-    func store(teams: [Team]) -> StoreOf<MolkkyPlayFeature> {
-        let initialState = MolkkyPlayFeature.State(teams: teams)
-        return Store(initialState: initialState,
-                     reducer: MolkkyPlayFeature())
-    }
-}
-
 // MARK: Previews
 struct TeamsOrderEditView_Previews: PreviewProvider {
     static var previews: some View {


### PR DESCRIPTION
# What changed?✨
- 1チームでプレイする時は並び順の設定が不要なので、プレイ順決定画面をスキップするようにした
- PageRouterをDestinationHelperView内で閉じて持たせるようにした
- デッドコード削除

# Impact range🔍
- チーム作成→プレイ順決定→プレイ
- 結果→プレイ順決定→プレイ
