### PR TITLE
バリデーションエラー発生時の不整合解消

### DIFF
--- a/MolkkyScoreBoard/MolkkyScoreBoard/UI/Result/Views/ResultTeamView.swift
+++ b/MolkkyScoreBoard/MolkkyScoreBoard/UI/Result/Views/ResultTeamView.swift
@@ -34,7 +34,9 @@ struct ResultTeamView: View {
 
                 HStack {
                     ForEach(team.members) { member in
-                        Text("\(member.name)さん ")
+                        let noName = "名無し"
+                        let memberName = member.name.isEmpty ? noName : member.name
+                        Text("\(memberName)さん ")
                     }
                     Spacer()
                 }

--- a/MolkkyScoreBoard/MolkkyScoreBoard/UI/TeamMake/NameFormsView.swift
+++ b/MolkkyScoreBoard/MolkkyScoreBoard/UI/TeamMake/NameFormsView.swift
@@ -52,15 +52,21 @@ private extension NameFormsView {
     /// バリデーションエラーを表示すべきか判定する
     /// - Parameters:
     ///   - datas: バリデーションエラーの情報
-    ///   - index: チームIndex
+    ///   - teamIndex: チームIndex
+    ///   - memberIndex: メンバーIndex
     /// - Returns: true: 表示する / false: 表示しない
     func shouldShowValidationError(from datas: [InvalidTeamIndex],
-                                   index: Int) -> Bool {
+                                   teamIndex: Int,
+                                   memberIndex: Int) -> Bool {
         guard !datas.isEmpty else {
             return false
         }
 
-        return datas.first(where: { $0.team == index }) != nil
+        let data = datas.first(where: {
+            ($0.team == teamIndex) && ($0.member == memberIndex)
+        })
+
+        return data != nil
     }
     
     /// フォームの背景色を設定する
@@ -72,9 +78,9 @@ private extension NameFormsView {
     func textFieldBackgroundColor(from datas: [InvalidTeamIndex],
                                   teamIndex: Int,
                                   memberIndex: Int) -> Color {
-        guard
-            shouldShowValidationError(from: datas, index: teamIndex),
-            datas.first(where: { $0.member == memberIndex }) != nil else {
+        guard shouldShowValidationError(from: datas,
+                                        teamIndex: teamIndex,
+                                        memberIndex: memberIndex) else {
             return .clear
         }
 

--- a/MolkkyScoreBoard/MolkkyScoreBoard/UI/TeamMake/TeamsMakeFeature.swift
+++ b/MolkkyScoreBoard/MolkkyScoreBoard/UI/TeamMake/TeamsMakeFeature.swift
@@ -74,6 +74,7 @@ struct TeamsMakeFeature: ReducerProtocol {
             state.teams[teamIndex].members.removeLast()
 
             removeValidationIfNeeded(from: teamIndex, memberIndex: membersLastIndex, with: &state)
+            updateEnableGoNext(with: &state)
             return .none
 
         case .didTapDecisionButton:
@@ -111,6 +112,12 @@ private extension TeamsMakeFeature {
             let index = InvalidTeamIndex(team: teamIndex,
                                          member: memberIndex,
                                          errorType: .maxLimitLength(count))
+
+            // invalidIndexに重複した情報が入るのを防ぐ
+            guard !state.invalidIndex.contains(index) else {
+                return
+            }
+
             state.invalidIndex.append(index)
         }
     }

--- a/MolkkyScoreBoard/MolkkyScoreBoard/UI/TeamsOrderEdit/Views/OrderingTeamView.swift
+++ b/MolkkyScoreBoard/MolkkyScoreBoard/UI/TeamsOrderEdit/Views/OrderingTeamView.swift
@@ -50,17 +50,22 @@ private extension OrderingTeamView {
             return ""
         }
 
+        let noName = "名無し"
+        let memberName = member.name.isEmpty ? noName : member.name
+
         switch members.count {
         case 1:
-            return "\(member.name)さん"
+            return "\(memberName)さん"
 
         case 2:
             let otherMember = members[1]
-            return "\(member.name)さんと\(otherMember.name)さん"
+            let otherMemberName = otherMember.name.isEmpty ? noName : otherMember.name
+            return "\(memberName)さんと\(otherMemberName)さん"
 
         case 3, 4:
             let otherMember = members[1]
-            return "\(member.name)さんと\(otherMember.name)さん 他"
+            let otherMemberName = otherMember.name.isEmpty ? noName : otherMember.name
+            return "\(memberName)さんと\(otherMemberName)さん 他"
 
         default:
             return ""


### PR DESCRIPTION
# What changed?✨
- バリデーションエラーが起きているメンバーを削除した際に決定ボタンが非活性のままになっている不具合を解消
- バリデーションエラーの確認ロジックを修正
- 名前がない時に「名無し」さんと表示させるようにした

# Impact range🔍
- チーム作成画面
- 結果画面

# Issues
- #23 
- #16 