### PR TITLE
プレイ中のチームの順番が回ってきた時の自動フォーカス

### DIFF
--- a/MolkkyScoreBoard/MolkkyScoreBoard/UI/MolkkyPlay/Views/Lower/TeamScoresRowsView.swift
+++ b/MolkkyScoreBoard/MolkkyScoreBoard/UI/MolkkyPlay/Views/Lower/TeamScoresRowsView.swift
@@ -25,6 +25,7 @@ struct TeamScoresRowsView: View {
                     Divider()
                         .padding(.top, 10)
                 }
+                .id(index) // スクロール用にidの紐付けが必要
                 .background(teamBackgroundColor(from: team, index: index))
             }
         }

--- a/MolkkyScoreBoard/MolkkyScoreBoard/UI/MolkkyPlay/Views/MolkkyPlayView.swift
+++ b/MolkkyScoreBoard/MolkkyScoreBoard/UI/MolkkyPlay/Views/MolkkyPlayView.swift
@@ -43,9 +43,11 @@ struct MolkkyPlayView: View {
                     SkittlesView(viewStore: viewStore)
                         .padding(.bottom, 10)
 
-                    PlayingButtonsView(viewStore: viewStore)
+                    ScrollViewReader { reader in
+                        PlayingButtonsView(viewStore: viewStore, reader: reader)
 
-                    TeamScoresView(viewStore: viewStore)
+                        TeamScoresView(viewStore: viewStore)
+                    }
                 }
             }
             .background(AppColor.base.color)

--- a/MolkkyScoreBoard/MolkkyScoreBoard/UI/MolkkyPlay/Views/Upper/PlayingButtonsView.swift
+++ b/MolkkyScoreBoard/MolkkyScoreBoard/UI/MolkkyPlay/Views/Upper/PlayingButtonsView.swift
@@ -15,6 +15,7 @@ struct PlayingButtonsView: View {
     let viewStore: ViewStore<MolkkyPlayFeature.State,
                              MolkkyPlayFeature.Action>
 
+    /// Reader
     let reader: ScrollViewProxy
 
     var body: some View {

--- a/MolkkyScoreBoard/MolkkyScoreBoard/UI/MolkkyPlay/Views/Upper/PlayingButtonsView.swift
+++ b/MolkkyScoreBoard/MolkkyScoreBoard/UI/MolkkyPlay/Views/Upper/PlayingButtonsView.swift
@@ -15,11 +15,17 @@ struct PlayingButtonsView: View {
     let viewStore: ViewStore<MolkkyPlayFeature.State,
                              MolkkyPlayFeature.Action>
 
+    let reader: ScrollViewProxy
+
     var body: some View {
         HStack() {
             let canUndo = !viewStore.state.undoActions.isEmpty
             Button("戻る") {
                 viewStore.send(.didTapUndoButton)
+
+                withAnimation (.default) {
+                    reader.scrollTo(viewStore.state.playingOrder)
+                }
             }
             .font(Font.system(size: 20))
             .foregroundColor(canUndo ? AppColor.white.color : .clear)
@@ -36,8 +42,13 @@ struct PlayingButtonsView: View {
 
             Button("決定") {
                 viewStore.send(.didTapDecideButton)
+
                 if viewStore.state.shouldFinishMatch {
                     viewStore.send(.finishMatch)
+                } else {
+                    withAnimation (.default) {
+                        reader.scrollTo(viewStore.state.playingOrder)
+                    }
                 }
             }
             .font(Font.system(size: 20))
@@ -50,15 +61,5 @@ struct PlayingButtonsView: View {
                                 bottom: 0,
                                 trailing: 10))
         }
-    }
-}
-
-// MARK: Previews
-struct PlayingButtonsView_Previews: PreviewProvider {
-    static var previews: some View {
-        let state = MolkkyPlayFeature.State(teams: TeamsMock().data)
-        let viewStore = ViewStore(StoreOf<MolkkyPlayFeature>(initialState: state,
-                                                             reducer: MolkkyPlayFeature()))
-        PlayingButtonsView(viewStore: viewStore)
     }
 }


### PR DESCRIPTION
# What changed?✨
- プレイ中、決定・戻るボタンを押した時に順番が回ってきたチームにフォーカスを合わせる

# Impact range🔍
プレイ画面

# Reference📜
- [ScrollViewReader](https://www.choge-blog.com/programming/swiftuilistscrolltospecifiedposition/)
