### PR TITLE
データの不整合を回避するためのリファクタリング

### DIFF
--- a/MolkkyScoreBoard/MolkkyScoreBoard/Model/PlayAction.swift
+++ b/MolkkyScoreBoard/MolkkyScoreBoard/Model/PlayAction.swift
@@ -8,7 +8,7 @@
 /// プレイ時のチームごとのアクションのデータ
 struct PlayAction: Equatable {
     /// チーム
-    let team: Team
+    let teams: [Team]
     /// プレイ順
     let playingOrder: Int
 }

--- a/MolkkyScoreBoard/MolkkyScoreBoard/Model/Team.swift
+++ b/MolkkyScoreBoard/MolkkyScoreBoard/Model/Team.swift
@@ -34,10 +34,10 @@ struct Team: Identifiable, Hashable {
     }
     
     /// 次の試合に向けたチームのデータを作成する
-    /// - Parameter team: Team
-    func teamForNextMatch(with team: Team) -> Team {
-        var newTeam = team
-        let newScore = TeamScore(from: team)
+    /// - Returns: リセットされたチームデータ
+    func teamForNextMatch() -> Team {
+        var newTeam = self
+        let newScore = TeamScore(from: self)
         newTeam.score.append(newScore)
 
         // 失敗回数と失格になったかのフラグをリセットする

--- a/MolkkyScoreBoard/MolkkyScoreBoard/Model/Team.swift
+++ b/MolkkyScoreBoard/MolkkyScoreBoard/Model/Team.swift
@@ -32,4 +32,18 @@ struct Team: Identifiable, Hashable {
         }.reduce(0, +)
         return totalScore
     }
+    
+    /// 次の試合に向けたチームのデータを作成する
+    /// - Parameter team: Team
+    func teamForNextMatch(with team: Team) -> Team {
+        var newTeam = team
+        let newScore = TeamScore(from: team)
+        newTeam.score.append(newScore)
+
+        // 失敗回数と失格になったかのフラグをリセットする
+        newTeam.mistakeCount = .zero
+        newTeam.isDisqualified = false
+
+        return newTeam
+    }
 }

--- a/MolkkyScoreBoard/MolkkyScoreBoard/UI/MolkkyPlay/MolkkyPlayFeature.swift
+++ b/MolkkyScoreBoard/MolkkyScoreBoard/UI/MolkkyPlay/MolkkyPlayFeature.swift
@@ -243,17 +243,13 @@ private extension MolkkyPlayFeature {
     /// 1チームだけ残った場合、自動的に50点を獲得させる
     /// - Parameter state: State
     func raiseMaxScoreIfNeeded(from state: inout State) {
-        guard isOnlyTeamRemained(from: state) else {
+        guard 
+            isOnlyTeamRemained(from: state),
+            let index = state.teams.firstIndex(where: { !$0.isDisqualified }) else {
             return
         }
 
-        for index in 0..<state.teams.count {
-            guard !state.teams[index].isDisqualified else {
-                continue
-            }
-
-            state.teams[index].score[state.setNo - 1].score = type(of: self).maxLimitScore
-        }
+        state.teams[index].score[state.setNo - 1].score = type(of: self).maxLimitScore
     }
 
     /// 複数チームでプレイ中に1チームだけ残ったかどうか

--- a/MolkkyScoreBoard/MolkkyScoreBoard/UI/MolkkyPlay/MolkkyPlayFeature.swift
+++ b/MolkkyScoreBoard/MolkkyScoreBoard/UI/MolkkyPlay/MolkkyPlayFeature.swift
@@ -102,12 +102,16 @@ struct MolkkyPlayFeature: ReducerProtocol {
             let playingOrder = state.playingOrder
             let team = state.teams[playingOrder]
 
+            // ※結果画面から戻ってきて、その後undoをせずに決定を押すと不要なログが残ってしまう
+            // よって、既に失格になっているチームの「決定」かを確認するようにしている
+            if !team.isDisqualified {
+                let action = PlayAction(team: team, playingOrder: playingOrder)
+                undoManager.add(action)
+                state.undoActions = undoManager.actions
+            }
+
             update(from: &state)
             resetSkittles(from: &state)
-
-            let action = PlayAction(team: team, playingOrder: playingOrder)
-            undoManager.add(action)
-            state.undoActions = undoManager.actions
 
             return .none
 
@@ -127,12 +131,6 @@ private extension MolkkyPlayFeature {
     /// 更新系の処理
     /// - Parameter state: State
     func update(from state: inout State) {
-        // ※結果画面から戻ったとき、失格チームが謝って得点を入れてしまった場合を想定して条件をつけています。
-//        if !state.shouldFinishMatch {
-//            updateScore(from: &state)
-//            updateMistakeCount(from: &state)
-//        }
-
         updateScore(from: &state)
         updateMistakeCount(from: &state)
 

--- a/MolkkyScoreBoard/MolkkyScoreBoard/UI/MolkkyPlay/Views/Lower/TeamScoresRowsView.swift
+++ b/MolkkyScoreBoard/MolkkyScoreBoard/UI/MolkkyPlay/Views/Lower/TeamScoresRowsView.swift
@@ -40,10 +40,12 @@ private extension TeamScoresRowsView {
     ///   - index: チームのインデックス
     /// - Returns: チーム行の背景色
     func teamBackgroundColor(from team: Team, index: Int) -> Color {
+        guard !team.isDisqualified else {
+            return .gray
+        }
+
         if viewStore.state.playingOrder == index {
             return AppColor.accent3.color
-        } else if team.isDisqualified {
-            return .gray
         } else {
             return .clear
         }

--- a/MolkkyScoreBoard/MolkkyScoreBoard/UI/Result/ResultFeature.swift
+++ b/MolkkyScoreBoard/MolkkyScoreBoard/UI/Result/ResultFeature.swift
@@ -40,7 +40,7 @@ struct ResultFeature: ReducerProtocol {
         case .didTapNextMatchButton:
             sortByPlayingOrder(from: &state)
 
-            let newTeams = state.teams.map { $0.teamForNextMatch(with: $0) }
+            let newTeams = state.teams.map { $0.teamForNextMatch() }
             let path: DestinationType = newTeams.count == 1 ? .play(teams: newTeams) : .teamOrderEdit(teams: newTeams)
             PageRouter.shared.path.append(path)
             return .none

--- a/MolkkyScoreBoard/MolkkyScoreBoard/UI/Result/ResultFeature.swift
+++ b/MolkkyScoreBoard/MolkkyScoreBoard/UI/Result/ResultFeature.swift
@@ -38,15 +38,10 @@ struct ResultFeature: ReducerProtocol {
             return .none
 
         case .didTapNextMatchButton:
-            resetIsDisqualified(from: &state)
             sortByPlayingOrder(from: &state)
 
-            state.teams.enumerated().forEach { index, team in
-                let newScore = TeamScore(from: team)
-                state.teams[index].score.append(newScore)
-            }
-
-            let path: DestinationType = state.teams.count == 1 ? .play(teams: state.teams) : .teamOrderEdit(teams: state.teams)
+            let newTeams = state.teams.map { $0.teamForNextMatch(with: $0) }
+            let path: DestinationType = newTeams.count == 1 ? .play(teams: newTeams) : .teamOrderEdit(teams: newTeams)
             PageRouter.shared.path.append(path)
             return .none
         }
@@ -55,17 +50,6 @@ struct ResultFeature: ReducerProtocol {
 
 // MARK: Private Methods
 private extension ResultFeature {
-    /// 失格のフラグを全てリセットする
-    /// - Parameter state: State
-    func resetIsDisqualified(from state: inout State) {
-        let teamCount = state.teams.count
-
-        for index in 0..<teamCount {
-            state.teams[index].mistakeCount = .zero
-            state.teams[index].isDisqualified = false
-        }
-    }
-
     /// プレイ順に入れ替える
     /// - Parameter state: State
     func sortByPlayingOrder(from state: inout State) {

--- a/MolkkyScoreBoard/MolkkyScoreBoard/UI/Result/Views/ResultView.swift
+++ b/MolkkyScoreBoard/MolkkyScoreBoard/UI/Result/Views/ResultView.swift
@@ -23,7 +23,6 @@ struct ResultView: View {
             }
         }
         .background(AppColor.base.color)
-        .navigationBarBackButtonHidden(true)
     }
 }
 


### PR DESCRIPTION
# What changed?✨
- プレイ画面で隠していたナビバーの戻るボタンを表示。
  - これによってデータの不整合が起きないように修正
  - 全ての画面で一つ前のデータをそのまま引き継ぐようにしていたので、新たなデータを生成するようにした
- プレイ画面のチームの列の背景色の適用順位が適切ではなかったので、修正

# Impact range🔍
- プレイ画面
- プレイ順決定画面
- 結果画面

# Reference📜
- 参考になるリンクがあれば書く
